### PR TITLE
[update][s] Float numbers shows correctly without trailing zeros

### DIFF
--- a/ckanext/dataexplorer/public/vendor/recline/recline.js
+++ b/ckanext/dataexplorer/public/vendor/recline/recline.js
@@ -861,10 +861,18 @@ this.recline.Model = this.recline.Model || {};
         return JSON.stringify(val);
       },
       number: function (val, field, doc) {
+        if (val === null || val === undefined) return '';
+        
         var format = field.get("format");
         if (format === "percentage") {
           return val + "%";
         }
+        
+        // For float values, preserve the exact representation
+        if (typeof val === 'number' && !Number.isInteger(val)) {
+          return val.toFixed(20).replace(/\.?0+$/, '').replace(/\.?0+e/, 'e');
+        }
+        
         return val;
       },
       string: function (val, field, doc) {


### PR DESCRIPTION
## Issue 134
- Issue Link: https://github.com/nhsbsa-data-analytics/Open-Data-Portal/issues/134

### Description
- Fixing the issue with trailing zeroes being trimmed in the nhs-dataexplorer viewer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved numeric value handling to return a clear empty output when data is missing.
	- Enhanced decimal number formatting for better precision and cleaner presentation of floating-point values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->